### PR TITLE
What about an on-demand GitHub Action?

### DIFF
--- a/.github/workflows/itinerant_codespell.yml
+++ b/.github/workflows/itinerant_codespell.yml
@@ -1,0 +1,15 @@
+name: itinerant_codespell
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'GitHub repo to check with codespell (user_name/repo_name)'
+        required: true
+jobs:
+  itinerant_codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pip install codespell
+      - run: echo "Spellchecking ${{ github.event.inputs.repo }}..."
+      - run: git clone https://github.com/${{ github.event.inputs.repo }}
+      - run: codespell --count --skip="*.po"  # --ignore-words-list="" --skip="*.css,*.js,*.json,*.lock,*.map,*.po,*.svg"


### PR DESCRIPTION
What about an on-demand GitHub Action that would create a pull request on another GitHub repo?

`itinerant_codespell` is a simple on-demand GitHub Action that allows a user to enter the _user_name/repo_name_ of any public repo on GitHub.  The Action clones that repo and then runs `codespell` on it.  This is a trivial example but any tool could be used in place of `codespell` and the idea could be extended to create a PR containing the changes made back to the remote repository.

A similar on-demand `itinerant_remove_print_statements.yml` could enable users to get all the advantages of this tool without installing it locally.

Thoughts?

![Screenshot 2022-06-05 at 07 04 00](https://user-images.githubusercontent.com/3709715/172035862-96b531e5-bbde-4725-91f7-55f1a8585f5d.png)